### PR TITLE
Add callback to success toast

### DIFF
--- a/frontend/src/components/Dashboard/NewTile/NewTile.tsx
+++ b/frontend/src/components/Dashboard/NewTile/NewTile.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Typography } from "@material-tailwind/react";
-import { ToastContainer, toast } from "react-toastify";
+import { toast } from "react-toastify";
 import { useParams } from "react-router-dom";
 import axios from "axios";
 import { componentMapping, componentNames } from "../ComponentMapping";

--- a/frontend/src/components/Dashboard/NewTile/NewTile.tsx
+++ b/frontend/src/components/Dashboard/NewTile/NewTile.tsx
@@ -13,10 +13,11 @@ type SaveType = "update" | "new";
 
 interface NewTileProps {
   onClose: () => void;
+  onSaveSuccess: (message: string) => void;
   tileId?: number | null;
 }
 
-export default function NewTile({ onClose, tileId }: NewTileProps) {
+export default function NewTile({ onClose, onSaveSuccess, tileId }: NewTileProps) {
   const [tileName, setTileName] = useState("");
   const [queryPrompt, setQueryPrompt] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -58,11 +59,11 @@ export default function NewTile({ onClose, tileId }: NewTileProps) {
   };
 
   const showSuccessToast = (saveType: SaveType) => {
-    toast.success(
+    const message =
       saveType === "update"
         ? "Tile updated successfully!"
-        : "New tile saved successfully!"
-    );
+        : "New tile saved successfully!";
+    onSaveSuccess(message);
   };
 
   const handleError = (error: any) => {
@@ -287,18 +288,6 @@ export default function NewTile({ onClose, tileId }: NewTileProps) {
           onSave={() => handleSave("new")}
           onUpdate={() => handleSave("update")}
           isLoading={isLoading}
-        />
-
-        <ToastContainer
-          className="pt-14"
-          position="top-right"
-          autoClose={3000}
-          hideProgressBar={false}
-          newestOnTop={false}
-          closeOnClick
-          rtl={false}
-          pauseOnFocusLoss
-          pauseOnHover
         />
 
         <InfoTooltip open={info} handler={handleInfo} />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -146,6 +146,11 @@ export default function DashboardPage() {
     );
   };
 
+  const handleTileSaved = (message: string) => {
+    console.log("Toast Message:", message);
+    toast.success(message);
+  };
+
   const deleteTile = async (tileId: number | undefined) => {
     setLoading(true);
     console.log("delete tile", tileId);
@@ -422,6 +427,7 @@ export default function DashboardPage() {
             fetchTiles();
           }}
           tileId={editingTileId}
+          onSaveSuccess={handleTileSaved}
         />
       </Dialog>
 


### PR DESCRIPTION
Currently, NewTile and DashboardPage displays toast. A better way would be to remove toast from NewTile, and propagate the success to the DashboardPage through a callback.